### PR TITLE
Fix 404 loop in Individual Verifications callout

### DIFF
--- a/content/building-with-passport/individual-verifications/introduction.mdx
+++ b/content/building-with-passport/individual-verifications/introduction.mdx
@@ -17,7 +17,7 @@ Unlike [Stamps-based verification](/building-with-passport/stamps), which aggreg
 Human Passport offers multiple verification methods:
 - **[Stamps](/building-with-passport/stamps)** - Aggregate multiple signals into a composite score. Best for general Sybil resistance.
 - **[Models](/building-with-passport/models)** - ML-powered scoring with zero user friction. Best for frictionless verification.
-- **[Individual Verifications](/building-with-passport/individual-verifications)** - Privacy-preserving KYC, phone, biometrics, and AML checks. Best for regulatory compliance or stronger identity guarantees.
+- **[Individual Verifications](/building-with-passport/individual-verifications/introduction)** - Privacy-preserving KYC, phone, biometrics, and AML checks. Best for regulatory compliance or stronger identity guarantees.
 </Callout>
 
 ## Why Individual Verifications?


### PR DESCRIPTION
## Summary

The "Individual Verifications" link in the Callout box on the introduction page pointed to `/building-with-passport/individual-verifications` (the index stub). That index page links back via `./introduction` which Nextra resolves as `/building-with-passport/introduction` — a 404.

Fixed by pointing directly to `/building-with-passport/individual-verifications/introduction`.

One line change.

## Reviewer

@lebraat