### PR TITLE
Fix typo, update support URLs, and minor doc cleanup

### DIFF
--- a/content/building-with-passport/embed/introduction.mdx
+++ b/content/building-with-passport/embed/introduction.mdx
@@ -25,7 +25,7 @@ Overall, the Passport Embeds component brings the power of Human Passport's iden
 
 <Callout type="info">
 **Please Note:**<br />
-While Embed currently only works with the [Passport Stamps verificaiton flow](/building-with-passport/stamps/passport-api), we are also working on enabling individual verification flows within Embed, including zk KYC, zk Biometrics, and zk Proof of Clean Hands.<br /><br />
+While Embed currently only works with the [Passport Stamps verification flow](/building-with-passport/stamps/passport-api), we are also working on enabling individual verification flows within Embed, including zk KYC, zk Biometrics, and zk Proof of Clean Hands.<br /><br />
 Join our [Developer Telegram group](https://t.me/+Mcp9RsRV7tVmYjZh) to stay updated on the latest features and get support.
 </Callout>
 
@@ -38,7 +38,7 @@ The user flow for Passport Embeds is as follows:
 3. Once connected, the component will fetch the user's Passport score if they have one.
 4. If the user's score is above a specified threshold (20 by default), the component will show a success state and inform you that the user is verified. If not, the component will automatically verify any web3 Stamps that the user qualifies for. 
 5. If the user's score is still below the threshold, the component will walk users through pages of different Stamps that they can verify to build up their score. Once they build up a high enough score, they will be notified that the program is unlocked and they can participate.
-6. [Future optional feature] Once a user builds up a high enough score, they can mint their Passport onchain to one of Passport's supported networks. Once done, they will be notified that the program is unlocked and they can participate.
+6. [Future customization] Once a user builds up a high enough score, they can mint their Passport onchain to one of Passport's supported networks. Once done, they will be notified that the program is unlocked and they can participate.
 
 ## Customizations
 

--- a/content/building-with-passport/individual-verifications/introduction.mdx
+++ b/content/building-with-passport/individual-verifications/introduction.mdx
@@ -62,7 +62,7 @@ For testing and development, sandbox versions are available:
 | Government ID (KYC) | [id.human.tech/sandbox/gov-id](https://id.human.tech/sandbox/gov-id) |
 | Phone | [id.human.tech/sandbox/phone](https://id.human.tech/sandbox/phone) |
 | Proof of Clean Hands | [id.human.tech/sandbox/clean-hands](https://id.human.tech/sandbox/clean-hands) |
-| Biometrics | Coming soon |
+| Biometrics | [id.human.tech/sandbox/biometrics](https://id.human.tech/sandbox/biometrics) |
 
 ## Supported Chains
 

--- a/content/building-with-passport/stamps/smart-contracts/introduction.mdx
+++ b/content/building-with-passport/stamps/smart-contracts/introduction.mdx
@@ -27,7 +27,7 @@ Minting Passports onchain is an optional feature for users. Not all users will a
 Passport data can be converted into onchain attestations that are stored and engaged with via the [Ethereum Attestation Service (EAS)](https://attest.sh/) or [Verax](https://ver.ax/), which make that data accessible to developers via smart contracts. This enables quadratic funding, rewards, governance, access control, and other programs to exist entirely onchain with their Passport integration. 
 
 A simplified onchain Passport data flow follows this process:
-1. A user decides to [mint their Passport onchain](https://support.passport.xyz/passport-knowledge-base/using-passport/onchain-passport) to one of the available networks via the Passport App.
+1. A user decides to [mint their Passport onchain](https://support.passport.human.tech/passport-knowledge-base/using-passport/onchain-passport) to one of the available networks via the Passport App.
 2. Passport creates a [Stamp (Passport)](https://optimism.easscan.org/schema/view/0xd7b8c4ffa4c9fd1ecb3f6db8201e916a8d7dba11f161c1b0b5ccf44ceb8e2a39) and [score](https://optimism.easscan.org/schema/view/0x6ab5d34260fca0cfcf0e76e96d439cace6aa7c3c019d7c4580ed52c6845e9c89) attestation, and mints them onchain to EAS and other attestation registries, depending on which network they choose.
 3. A developer utilizes our [smart contract stack](/building-with-passport/stamps/smart-contracts/contract-reference#how-to-query-for-onchain-passport-data) and users' wallet addresses to request the Passport data from these onchain attestation registries.
 4. The developer uses this Passport data in their web3 programs to satisfy their [use case](/overview/use-cases).

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -16,7 +16,7 @@ These developer docs describe the different Human Passport developer products an
 
 <Callout type="info">
 **Passport Users:**<br />
-If you are a Passport user, please refer to the [Passport Support Center](https://support.passport.xyz) for help with your Passport account. If you are a developer building with Human Passport, please continue below to learn more about the different developer products and services.
+If you are a Passport user, please refer to the [Passport Support Center](https://support.passport.human.tech) for help with your Passport account. If you are a developer building with Human Passport, please continue below to learn more about the different developer products and services.
 </Callout>
 
 ## Developer Products and Services

--- a/content/overview/changelog.mdx
+++ b/content/overview/changelog.mdx
@@ -26,7 +26,7 @@ We launched a new Stamp to the Passport Stamps product.
 
 The new Stamp is called Proof of Clean Hands, and it checks to see if a given address and associated government ID is listed on any sanctions lists, including but not limited to the OFAC sanctions list, all US sanctions lists, and specific UN lists. 
 
-you can learn more about this Stamp via our [Proof of Clean Hands documentation](https://support.passport.xyz/passport-knowledge-base/stamps/how-do-i-add-passport-stamps/the-proof-of-clean-hands-stamp). If a user has verified this Stamp, you will be able to see that they verified this Stamp via the [Stamps API](/building-with-passport/stamps/passport-api) and [smart contracts](/building-with-passport/stamps/smart-contracts).
+you can learn more about this Stamp via our [Proof of Clean Hands documentation](https://support.passport.human.tech/passport-knowledge-base/stamps/how-do-i-add-passport-stamps/the-proof-of-clean-hands-stamp). If a user has verified this Stamp, you will be able to see that they verified this Stamp via the [Stamps API](/building-with-passport/stamps/passport-api) and [smart contracts](/building-with-passport/stamps/smart-contracts).
 
 ## May 12th, 2025
 


### PR DESCRIPTION
## Summary
- Fix "verificaiton" → "verification" typo in Embed introduction
- Update `support.passport.xyz` → `support.passport.human.tech` across 3 pages (index, changelog, smart contracts intro) — old URL 301 redirects, this uses the canonical domain directly
- Normalize `[Future optional feature]` → `[Future customization]` in Embed for consistency
- Add biometrics sandbox link (endpoint is now live, was previously "Coming soon")

## Files changed
- `content/building-with-passport/embed/introduction.mdx`
- `content/building-with-passport/individual-verifications/introduction.mdx`
- `content/building-with-passport/stamps/smart-contracts/introduction.mdx`
- `content/index.mdx`
- `content/overview/changelog.mdx`

## Test plan
- [ ] Verify Vercel preview deploy renders all 5 pages correctly
- [ ] Confirm `support.passport.human.tech` links resolve
- [ ] Confirm `id.human.tech/sandbox/biometrics` loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)