### PR TITLE
GEO: TechArticle schema + canonical docs.passport.human.tech

### DIFF
--- a/app/[[...mdxPath]]/page.tsx
+++ b/app/[[...mdxPath]]/page.tsx
@@ -15,15 +15,38 @@ type PageProps = {
   }>
 }
 
+const SITE = 'https://docs.passport.human.tech'
+
 export default async function Page(props: PageProps) {
   const params = await props.params
   const result = await importPage(params.mdxPath)
   const { default: MDXContent, toc, metadata } = result
   const Wrapper = useMDXComponents().wrapper
 
+  const md = metadata as { title?: unknown; description?: unknown } | undefined
+  const title = typeof md?.title === 'string' ? md.title : undefined
+  const description = typeof md?.description === 'string' ? md.description : undefined
+  const path = (params.mdxPath ?? []).join('/')
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: title || 'Human Passport Documentation',
+    ...(description ? { description } : {}),
+    url: path ? `${SITE}/${path}` : SITE,
+    inLanguage: 'en',
+    isPartOf: { '@type': 'WebSite', name: 'Human Passport Developer Docs', url: SITE },
+    publisher: { '@type': 'Organization', name: 'human.tech', url: 'https://human.tech' },
+  }
+
   return (
-    <Wrapper toc={toc} metadata={metadata}>
-      <MDXContent {...props} params={params} />
-    </Wrapper>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <Wrapper toc={toc} metadata={metadata}>
+        <MDXContent {...props} params={params} />
+      </Wrapper>
+    </>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,6 +56,10 @@ const telegramIcon = (
 )
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://docs.passport.human.tech'),
+  alternates: {
+    canonical: './'
+  },
   title: {
     default: 'Human Passport',
     template: '%s – Human Passport'
@@ -66,13 +70,13 @@ export const metadata: Metadata = {
     title: 'Human Passport',
     description: 'Human Passport — Sybil Defense. Made Simple',
     site: '@humnpassport',
-    images: ['https://docs.passport.xyz/social-card.png']
+    images: ['https://docs.passport.human.tech/social-card.png']
   },
   openGraph: {
     title: 'Human Passport',
     description: 'Human Passport — Sybil Defense. Made Simple',
-    images: ['https://docs.passport.xyz/social-card.png'],
-    url: 'https://docs.passport.xyz'
+    images: ['https://docs.passport.human.tech/social-card.png'],
+    url: 'https://docs.passport.human.tech'
   },
   icons: {
     icon: [

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: process.env.SITE_URL || "https://docs.passport.xyz",
+  siteUrl: process.env.SITE_URL || "https://docs.passport.human.tech",
   generateRobotsTxt: true,
   exclude: [
     // Retired v1 API pages - excluded from search engines and AI crawlers


### PR DESCRIPTION
Technical GEO pass for the Passport dev docs (fork-PR; I have READ on passportxyz/passport-docs). Mirrors the WaaP docs pass (holonym-foundation/waap-docs#129).

- **TechArticle** JSON-LD per doc page — the gap (was no schema)
- metadataBase + self-canonical + OG/Twitter → `docs.passport.human.tech` (canonical, per Karo; docs.passport.xyz already 301s here)
- next-sitemap `siteUrl` default `docs.passport.xyz` → `docs.passport.human.tech` so the sitemap lists canonical URLs (today it lists docs.passport.xyz URLs that then 301)

robots.txt + sitemap.xml + llms.txt already exist via next-sitemap.

⚠️ If a `SITE_URL` env var is set to docs.passport.xyz on the deploy, it overrides the config default — that'd also need updating for the sitemap to emit canonical URLs.

cc @nanaknihal for review/merge (dev-docs ownership in transition since Daniel left).